### PR TITLE
Refactor `convert_json_to_yaml` function to maintain key order and skip certain keys

### DIFF
--- a/convert-json-yaml.py
+++ b/convert-json-yaml.py
@@ -7,7 +7,7 @@ def convert_json_to_yaml(input_dir, output_file):
     yaml_data = []
 
     # Define the order of keys to be maintained
-    key_order = ['id', 'alias', 'description', 'trigger', 'condition', 'action']
+    key_order = ['id', 'alias', 'description']
 
     # Loop through each file in the directory
     for filename in os.listdir(input_dir):
@@ -15,13 +15,25 @@ def convert_json_to_yaml(input_dir, output_file):
             file_path = os.path.join(input_dir, filename)
             with open(file_path, 'r') as json_file:
                 data = json.load(json_file)
+
+                # Check for use_blueprint key and remove specific keys if it exists
+                if 'use_blueprint' in data:
+                    keys_to_skip = {'trigger', 'condition', 'action'}
+                else:
+                    keys_to_skip = set()
                 
-                # Create an ordered dictionary to maintain key order
+                # Create an ordered dictionary to maintain key order and skip certain keys if necessary
                 ordered_data = {key: data.get(key) for key in key_order}
                 
-                # Add any remaining keys that are not in the predefined order
+                if not keys_to_skip:
+                    # Add optional keys only if they should not be skipped
+                    optional_keys = ['trigger', 'condition', 'action']
+                    for key in optional_keys:
+                        ordered_data[key] = data.get(key)
+
+                # Add any remaining keys that are not in the predefined order or skipped list 
                 for key in data:
-                    if key not in ordered_data:
+                    if (key not in ordered_data) and (key not in keys_to_skip):
                         ordered_data[key] = data[key]
                 
                 yaml_data.append(ordered_data)


### PR DESCRIPTION
fixes #1 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility in JSON to YAML conversion based on the presence of the `use_blueprint` key, allowing for customized outputs.
- **Bug Fixes**
	- Improved handling of key processing to ensure accurate inclusion of relevant keys in the final YAML output, regardless of input structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->